### PR TITLE
Bump Storybook to 7.6.12

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -603,9 +603,9 @@
     semver "^6.3.1"
 
 "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.23.6":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz#fddfdf51fca28f23d16b9e3935a4732690acfad6"
-  integrity sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==
+  version "7.23.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz#25d55fafbaea31fd0e723820bb6cc3df72edf7ea"
+  integrity sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-environment-visitor" "^7.22.20"
@@ -1579,7 +1579,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.17.8", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4", "@babel/runtime@~7.23.1":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.17.8", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.8.4", "@babel/runtime@~7.23.1":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
@@ -3724,139 +3724,139 @@
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
 "@storybook/addon-a11y@~7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-7.6.11.tgz#25bd016e85031e7c3f5db8bcc5c5c7b3c566e01f"
-  integrity sha512-HCXewZ6CD1DRjbkMGAManDZFrNkZraL6dn5iYY6k9cEwz05pbCV9NOoUzknArgEQB9FKy+dCU/xiILsA9h0Ntw==
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-7.6.12.tgz#8bdf95dbd54b4a5151e19383a760cd2a2f209764"
+  integrity sha512-Y4vGTI7VslAt/PSpZZsFieceOkXHLagTsz9Zba4s1cw7Dd8KFB1+NcjkMmo6BhGq7K17JQljosXSbGhOoqrMVg==
   dependencies:
-    "@storybook/addon-highlight" "7.6.11"
+    "@storybook/addon-highlight" "7.6.12"
     axe-core "^4.2.0"
 
-"@storybook/addon-actions@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.6.11.tgz#15cc1f4dcf9cc6d8ae8d372611a6eb8f3c5f67b7"
-  integrity sha512-HdL1p4mKVnomr72vQKd1G4F5BeFXxEYTwJdUXg0slX+q2vPhsNHzvCiYapdtzkRfbxhW75Y2WP6EJ7K55DelVw==
+"@storybook/addon-actions@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.6.12.tgz#9f8ec7ea0b656699ea7b69caf29a7e0e8e482d31"
+  integrity sha512-vK/H6K+AJ4ZSsCu/+MapYYI/xrynB6JoCOejt//flTigZOhwTWv7WXbmEeqGIIToXy0LA2IUZ1/kCjFXR0lEdQ==
   dependencies:
-    "@storybook/core-events" "7.6.11"
+    "@storybook/core-events" "7.6.12"
     "@storybook/global" "^5.0.0"
     "@types/uuid" "^9.0.1"
     dequal "^2.0.2"
     polished "^4.2.2"
     uuid "^9.0.0"
 
-"@storybook/addon-backgrounds@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.6.11.tgz#26d5a08e88adb49dcb38a3f6dd4ed614ca467e3b"
-  integrity sha512-Tzgn5AqNFcehPNeohrY4fJsCFjux2GnJQDHKWt/jeAtkbDVUd4VOZBxR6SMEnuLOsR3tywJh7tf2PgRNCc1hzw==
+"@storybook/addon-backgrounds@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.6.12.tgz#5ef6121eb8762a5a9e4193ac079ed7b7b9132d95"
+  integrity sha512-G14uN5lDXUtXw+dmEPaB6lpDpR9K25ssYuWWn8yYR44B1WMuD4kDgw0QGb0g+xYQj9R1TsalKEJHA4AuSYkVGQ==
   dependencies:
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-controls@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.6.11.tgz#7c708625f02bfba9b4fc6b59dec2505533295dc3"
-  integrity sha512-zoj9rkoUoZN+SWJ7v6rUTGyZKAXbKB6OqvgOCHMPV8W6Fro6JbwIDReiLs477yyxDQb0gsRV/akicG8EqBwyJQ==
+"@storybook/addon-controls@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.6.12.tgz#e45c2fcd320ed39d9ace91d612d76fc74d2c2750"
+  integrity sha512-NX4KajscOsuXyYE3hhniF+y0E59E6rM0FgIaZ48P9c0DD+wDo8bAISHjZvmKXtDVajLk4/JySvByx1eN6V3hmA==
   dependencies:
-    "@storybook/blocks" "7.6.11"
+    "@storybook/blocks" "7.6.12"
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.6.11.tgz#6043cf14a51d805596810cde9aca00a765a0d0cc"
-  integrity sha512-q9/cJ9+NgMrCjbfc0W0DH5VuKlyUkmBXgp7Vp7pvncrltIfdDdmeK46xEo7zKKisTXpH7YCmaFZFpiMRtWZ3oQ==
+"@storybook/addon-docs@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.6.12.tgz#e08ff52c3693eaa3fa81bb4065b6d28740a246c5"
+  integrity sha512-AzMgnGYfEg+Z1ycJh8MEp44x1DfjRijKCVYNaPFT6o+TjN/9GBaAkV4ydxmQzMEMnnnh/0E9YeHO+ivBVSkNog==
   dependencies:
     "@jest/transform" "^29.3.1"
     "@mdx-js/react" "^2.1.5"
-    "@storybook/blocks" "7.6.11"
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/components" "7.6.11"
-    "@storybook/csf-plugin" "7.6.11"
-    "@storybook/csf-tools" "7.6.11"
+    "@storybook/blocks" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/components" "7.6.12"
+    "@storybook/csf-plugin" "7.6.12"
+    "@storybook/csf-tools" "7.6.12"
     "@storybook/global" "^5.0.0"
     "@storybook/mdx2-csf" "^1.0.0"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/postinstall" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/react-dom-shim" "7.6.11"
-    "@storybook/theming" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/postinstall" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/react-dom-shim" "7.6.12"
+    "@storybook/theming" "7.6.12"
+    "@storybook/types" "7.6.12"
     fs-extra "^11.1.0"
     remark-external-links "^8.0.0"
     remark-slug "^6.0.0"
     ts-dedent "^2.0.0"
 
 "@storybook/addon-essentials@~7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.6.11.tgz#7b997948aaa23b57a6944807474671be7c043ba9"
-  integrity sha512-wHcs0Ar0Or3bMDU7338rhGq3Hl79S80vdcVpCxuNhb0KJtX4IoAID6nTbjLHGOAjjQgYBZJwOX7L0YMYvSxwsA==
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.6.12.tgz#14e7d43a0d71d9bb9027143dece3ee543ade77ca"
+  integrity sha512-Pl6n+19QC/T+cuU8DZjCwILXVxrdRTivNxPOiy8SEX+jjR4H0uAfXC9+RXCPjRFn64t4j1K7oIyoNokEn39cNw==
   dependencies:
-    "@storybook/addon-actions" "7.6.11"
-    "@storybook/addon-backgrounds" "7.6.11"
-    "@storybook/addon-controls" "7.6.11"
-    "@storybook/addon-docs" "7.6.11"
-    "@storybook/addon-highlight" "7.6.11"
-    "@storybook/addon-measure" "7.6.11"
-    "@storybook/addon-outline" "7.6.11"
-    "@storybook/addon-toolbars" "7.6.11"
-    "@storybook/addon-viewport" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/manager-api" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
+    "@storybook/addon-actions" "7.6.12"
+    "@storybook/addon-backgrounds" "7.6.12"
+    "@storybook/addon-controls" "7.6.12"
+    "@storybook/addon-docs" "7.6.12"
+    "@storybook/addon-highlight" "7.6.12"
+    "@storybook/addon-measure" "7.6.12"
+    "@storybook/addon-outline" "7.6.12"
+    "@storybook/addon-toolbars" "7.6.12"
+    "@storybook/addon-viewport" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/manager-api" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-highlight@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.6.11.tgz#af6adb0d9f252509c9a65a2d7d7383b9b27082a4"
-  integrity sha512-/uR/k0xA4dj4E4MHRSxb9UHBslDG51V10x6We8cqpWPGMVd3qDDkR3DJg8Ix0CdRVsnSQFTv9+BkDH707v4nCQ==
+"@storybook/addon-highlight@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.6.12.tgz#7fc702ae29221b32b8c6ae1dd76071e99aae8042"
+  integrity sha512-rWNEyBhwncXEDd9z7l67BLBIPqn0SRI/CJpZvCSF5KLWrVaoSEDF8INavmbikd1JBMcajJ28Ur6NsGj+eJjJiw==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/addon-measure@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.6.11.tgz#6c626cd8728d468e38197ecd6ad36fc613c48c3c"
-  integrity sha512-0Tyf5HPHgXtPVgakdtPzY+YjOPSA3vr8aM3Z6Qbg1YhcC0Oh94VnhZNzMDkKbmIc7h7bPLxtmshdBjEImLjG0Q==
+"@storybook/addon-measure@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.6.12.tgz#6f037866d3e19d36b09d6dc342a053eee9c8055a"
+  integrity sha512-K3aKErr84V0eVK7t+wco5cSYDdeotwoXi4e7VLSa2cdUz0wanOb4R7v3kf6vxucUyp05Lv+yHkz9zsbwuezepA==
   dependencies:
     "@storybook/global" "^5.0.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/addon-outline@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.6.11.tgz#46fe2186e7836a33fcae88f499eaa6ac4c036952"
-  integrity sha512-FryUAV2zN7A78RTo1pBz8NPt7JrbTp6AeS2VNjKiwq0V8SOWHEwTBE4ECW2rrNd53t3pJaD4SEh5xOTgJpH5uA==
+"@storybook/addon-outline@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.6.12.tgz#a3162724cbcb59d71198a641e99b50d3a4eef218"
+  integrity sha512-r6eO4EKh+zwGUNjxe8v/44BhyV+JD3Dl9GYMutsFqbwYsoWHJaZmzHuyqeFBXwx2MEoixdWdIzNMP71+srQqvw==
   dependencies:
     "@storybook/global" "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.6.11.tgz#0b5d9cedc0852b890a79c99d3ea345803b5e08fd"
-  integrity sha512-VTUR4xjLZFIAHJVzN999muEbnhRhs14tA4BpHTE4Xz9jvqGiKbbpT76k8iVy4hG6Rb1b6xY9K/uNy3W3elImKQ==
+"@storybook/addon-toolbars@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.6.12.tgz#28ecb784cdf1d319f1d5d5428fbcdbd12df676ac"
+  integrity sha512-TSwq8xO7fmS6GRTgJJa31OBzm+5zlgDYK2Q42jxFo/Vm10uMzCpjYJE6mIHpUDyjyBVQk6xxMMEcvo6no2eAWg==
 
-"@storybook/addon-viewport@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.6.11.tgz#acb5dc867810f0b0e8aadd156eccbde28d0b1d86"
-  integrity sha512-h0sa27uGs7d1yjEj4GrCilk6jp69jmYZ9fsvQkR3EAJh8k60MuJc9JvXNhH5/FdQtCzX+eJTn0vPkNFnoRRjHw==
+"@storybook/addon-viewport@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.6.12.tgz#2bfde2d98ded4693f9821b7d67b03fcc3dc73346"
+  integrity sha512-51zsBeoaEzq699SKDCe+GG/2PDAJKKJtpjqxIc4lDskogaCJSb3Ie8LyookHAKYgbi2qealVgK8zaP27KUj3Pg==
   dependencies:
     memoizerific "^1.11.3"
 
-"@storybook/blocks@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.6.11.tgz#caf010cf9a0f17b162ef8ead07b7abcb9df16421"
-  integrity sha512-Oq988/KB5/deUH10jy013K5IQRRetfjS4La2+/QeJxqQRvBf4CBycNab9DalHJkwboKBV8OBTw9sbQFU32AMuQ==
+"@storybook/blocks@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.6.12.tgz#ec3517cd3d91e8eb9639b7abe8f4b306bb0fbd19"
+  integrity sha512-T47KOAjgZmhV+Ov59A70inE5edInh1Jh5w/5J5cjpk9a2p4uhd337SnK4B8J5YLhcM2lbKRWJjzIJ0nDZQTdnQ==
   dependencies:
-    "@storybook/channels" "7.6.11"
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/components" "7.6.11"
-    "@storybook/core-events" "7.6.11"
+    "@storybook/channels" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/components" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/csf" "^0.1.2"
-    "@storybook/docs-tools" "7.6.11"
+    "@storybook/docs-tools" "7.6.12"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/theming" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/manager-api" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/theming" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/lodash" "^4.14.167"
     color-convert "^2.0.1"
     dequal "^2.0.2"
@@ -3870,15 +3870,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.11.tgz#6b0ecfdfa0de13f5bf7a947fa2598933cc0ec883"
-  integrity sha512-cJW3jQbyQHFK83k6fcXiP0hcyBaRiSLBxcbt+ccu6r1Hb7RNo4NlmQQQZF2hTpcm6wNGI0mmkUzwMdfbKIiZ9A==
+"@storybook/builder-manager@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.12.tgz#6dd6ed1e0b440d7dd26dc5438e5e765aa464212e"
+  integrity sha512-AJFrtBj0R11OFwwz+2j+ivRzttWXT6LesSGoLnxown24EV9uLQoHtGb7GOA2GyzY5wjUJS9gQBPGHXjvQEfLJA==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/manager" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/manager" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -3892,20 +3892,20 @@
     process "^0.11.10"
     util "^0.12.4"
 
-"@storybook/builder-webpack5@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.6.11.tgz#afa51a8778b32651e44f20cfda1b9f6a4a8836d5"
-  integrity sha512-RpvvSyf7OXy5z+dWvjVNi8cQe+A9kcoAHZ7JWy6ogZLAkGGHUO4cXkNSFf7pk0543n4gGYtcFBpCV9we64TB+Q==
+"@storybook/builder-webpack5@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.6.12.tgz#e089065de5de48fed47442d07d719e3a4d1f61cc"
+  integrity sha512-6y5hfMV2rqKbloGZ8CicCH1UQd6sdiFdHf6/5Wo4tBoaGYzQjPM/cV1fizsO/01GG0yGJg7J6BohTiCCbNdGCA==
   dependencies:
     "@babel/core" "^7.23.2"
-    "@storybook/channels" "7.6.11"
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/core-events" "7.6.11"
-    "@storybook/core-webpack" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/preview" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
+    "@storybook/channels" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/core-webpack" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/preview" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
     "@swc/core" "^1.3.82"
     "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
@@ -3936,35 +3936,35 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.5.0"
 
-"@storybook/channels@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.11.tgz#89986555e72fc4f726a97df6e34cb5c34fa2d9b7"
-  integrity sha512-MtlffM4aZyCD5Npr+oT1aZvJmfDaFeHSTpIybGlmT4By+RgbxWDl/qWnqdo/VlqBWbtBASBtzqgLR/knC+5j1A==
+"@storybook/channels@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.12.tgz#eafcbb1c26de94ed15db62dd0f8ea88d20154312"
+  integrity sha512-TaPl5Y3lOoVi5kTLgKNRX8xh2sUPekH0Id1l4Ymw+lpgriEY6r60bmkZLysLG1GhlskpQ/da2+S2ap2ht8P2TQ==
   dependencies:
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-events" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/global" "^5.0.0"
     qs "^6.10.0"
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/cli@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.11.tgz#3158377800d6397edb7682be19fd144ea65347eb"
-  integrity sha512-ohKjys/amKuJllqBggF/VOaGNr6mnfXB8lYFXucBUGSyesWJJgaqKo6EAPnsp48EBU1xv0xlcg0655WCemvZcA==
+"@storybook/cli@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.12.tgz#f114dc71799eec60cf92c1462c2418ae11711246"
+  integrity sha512-x4sG1oIVERxp+WnWUexVlgaJCFmML0kGi7a5qfx7z4vHMxCV/WG7g1q7mPS/kqStCGEiQdTciCqOEFqlMh9MLw==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/core-events" "7.6.11"
-    "@storybook/core-server" "7.6.11"
-    "@storybook/csf-tools" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/telemetry" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/codemod" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/core-server" "7.6.12"
+    "@storybook/csf-tools" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/telemetry" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/semver" "^7.3.4"
     "@yarnpkg/fslib" "2.10.3"
     "@yarnpkg/libzip" "2.3.0"
@@ -3994,25 +3994,25 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-logger@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.11.tgz#2fed783b5f21bf6b3b607c8acc8d35162026d850"
-  integrity sha512-1FuC1Lf8TMjeKj4rE5fFt7j4zsWkQQlKPDgEw+AB72QDiiR33ZKajUkBkFvjmngMSMleR+uUeLY0DnmeZkvQhw==
+"@storybook/client-logger@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.12.tgz#ee571b22e6f31a3d2fd1ad357a5725f46cfb6ded"
+  integrity sha512-hiRv6dXsOttMPqm9SxEuFoAtDe9rs7TUS8XcO5rmJ9BgfwBJsYlHzAxXkazxmvlyZtKL7gMx6m8OYbCdZgUqtA==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.11.tgz#ebc8387451a2c5bd8c571bce27b4b49563e9b9bd"
-  integrity sha512-xOWXaCFOz22ZnlErxm9ZYmr5gGp1fp0q2iD1QOASFNYdnCRmw2TJ9MRrVNPBxlmlSvsD8zPUkWhiAmcTmOPF1A==
+"@storybook/codemod@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.12.tgz#a450327ea43e6684d028968477d5f895c8905c93"
+  integrity sha512-4EI4Ah1cvz6gFkXOS/LGf23oN8LO6ABGpWwPQoMHpIV3wUkFWBwrKFUe/UAQZGptnM0VZRYx4grS82Hluw4XJA==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/csf-tools" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/cross-spawn" "^6.0.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -4021,38 +4021,38 @@
     prettier "^2.8.0"
     recast "^0.23.1"
 
-"@storybook/components@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.6.11.tgz#45b2acda7f8c38267a660b23363d0670e864413b"
-  integrity sha512-ikGl5MQkWItEkLu5Y7MU1KpLI75BSUQcnAt3T/6P+HOHbUrCckEyQEvHUsf56s1hkmXOtUY5Cy8dWTH5+MxarQ==
+"@storybook/components@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.6.12.tgz#7833ecc17da716a30bd2f40bbceb11306c762b61"
+  integrity sha512-PCijPqmlZd7qyTzNr+vD0Kf8sAI9vWJIaxbSjXwn/De3e63m4fsEcIf8FaUT8cMZ46AWZvaxaxX5km2u0UISJQ==
   dependencies:
     "@radix-ui/react-select" "^1.2.2"
     "@radix-ui/react-toolbar" "^1.0.4"
-    "@storybook/client-logger" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/theming" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/theming" "7.6.12"
+    "@storybook/types" "7.6.12"
     memoizerific "^1.11.3"
     use-resize-observer "^9.1.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-client@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.6.11.tgz#9974c7c351196bca2fcbb7ca975c278bbbb16f26"
-  integrity sha512-QWK1Q5iMkfQZP40/DnaqRLrLqN1jxgKwk+kMGvtH/rhDKKa13NRuVh7Ka+WCfR5Kcl7xUQlZnWFMVz9rM41Epw==
+"@storybook/core-client@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.6.12.tgz#4c8bb87286002fc908f6652df383edbaae79b321"
+  integrity sha512-VzVp32tMZsCzM4UIqfvCoJF7N9mBf6dsAxh1/ZgViy75Fht78pGo3JwZXW8osMbFSRpmWD7fxlUM5S7TQOYQug==
   dependencies:
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
 
-"@storybook/core-common@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.11.tgz#100b7ba0dbd5990cfc98300333346ee9890c6111"
-  integrity sha512-hdmu+Oxj/Uold1Vasbs2741ChCJzFC5KvxuIuymwhjBlGsj7M5HWgtMujFY//S8G1TWPXnGf6ZK2Wj+F0gjXgw==
+"@storybook/core-common@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.12.tgz#a42bdcdb5c68aafcf57492666ad99cfe8261e3f9"
+  integrity sha512-kM9YiBBMM2x5v/oylL7gdO1PS4oehgJC21MivS9p5QZ8uuXKtCQ6UQvI3rzaV+1ZzUA4n+I8MyaMrNIQk8KDbw==
   dependencies:
-    "@storybook/core-events" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/find-cache-dir" "^3.2.1"
     "@types/node" "^18.0.0"
     "@types/node-fetch" "^2.6.4"
@@ -4074,33 +4074,33 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.11.tgz#a7fef3be3bdf293cde0cdcad456514932d2d7121"
-  integrity sha512-7Bg9hjIaZlHCAvoVjYCl7C+16ZVvciqC0hQhJCYYCVpiVYoXA1jAB6sE1gsaDeWYtzfkLHgQEytRj6Ot3e2rfQ==
+"@storybook/core-events@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.12.tgz#b622a51ee905ca1adb83163a912bb9dcfee3ba4a"
+  integrity sha512-IO4cwk7bBCKH6lLnnIlHO9FwQXt/9CzLUAoZSY9msWsdPppCdKlw8ynJI5YarSNKDBUn8ArIfnRf0Mve0KQr9Q==
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-server@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.11.tgz#41592c920fb32b6dd4f40a937da8ff8c41af5901"
-  integrity sha512-ZUgWv372Z1FBI8MynBh1kR7pUE2dAZ/dAyxMd9NzoyW3IBjM/RCcoL2oSDmWs668idDgXL3z4SQqSpWOh0YMaQ==
+"@storybook/core-server@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.12.tgz#486d022758dc7bbcc088e3d8d454404464f568dc"
+  integrity sha512-tjWifKsDnIc8pvbjVyQrOHef70Gcp93Bg3WwuysB8PGk7lcX2RD9zv44HNIyjxdOLSSv66IGKrOldEBL3hab4w==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.126"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.6.11"
-    "@storybook/channels" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/core-events" "7.6.11"
+    "@storybook/builder-manager" "7.6.12"
+    "@storybook/channels" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.11"
+    "@storybook/csf-tools" "7.6.12"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/telemetry" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/manager" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/telemetry" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^18.0.0"
     "@types/pretty-hrtime" "^1.0.0"
@@ -4128,36 +4128,36 @@
     watchpack "^2.2.0"
     ws "^8.2.3"
 
-"@storybook/core-webpack@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.6.11.tgz#dc978b698051f6c5f4095bf82e574b44f9259b41"
-  integrity sha512-zWSoeAlK7iR4yV1MaInUTIKmKuBKwTkOzR3McVCxz7E2e3mXmQIcufOzDr9qTBHUHj4sot2RPx6ofsVJw4LoNA==
+"@storybook/core-webpack@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.6.12.tgz#896c0b0e8a8805b030175c054fab2323efafcc12"
+  integrity sha512-Dm42mZHXHaroqrZyY8pMWjAQIxzZDFC8JI9uEWboFfE8xm+UXMmW7E0bsa+xQCZ5iAt2SusAUcwSOaYacXHb+Q==
   dependencies:
-    "@storybook/core-common" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/node" "^18.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/csf-plugin@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.6.11.tgz#197bb0427993c5994ea92da22f25a077ccc1ab11"
-  integrity sha512-99K1TMUnJ4gKwcnxii5wQnc2mw07GfWivEIcrHj7gpNLFSWt4MxWfNBGtnuY8gk43fRD0NLaKscKTADrL+q72Q==
+"@storybook/csf-plugin@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.6.12.tgz#c8402dba986651d703a538c8602c2a7bbc635243"
+  integrity sha512-fe/84AyctJcrpH1F/tTBxKrbjv0ilmG3ZTwVcufEiAzupZuYjQ/0P+Pxs8m8VxiGJZZ1pWofFFDbYi+wERjamQ==
   dependencies:
-    "@storybook/csf-tools" "7.6.11"
+    "@storybook/csf-tools" "7.6.12"
     unplugin "^1.3.1"
 
-"@storybook/csf-tools@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.11.tgz#4fe1895c7abd268d7ff1d2da19311228f8a17974"
-  integrity sha512-S0dwjhfEWaRm41Illqzvj9VCiQ9NsSQA6pjIbK1GRMpFvL5+uaXQ08YYgnVPLs6Qhe98V0v1uUdZ7Y1HXdt1Og==
+"@storybook/csf-tools@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.12.tgz#42ef641a2bcc2feaff167d68ea5b58aebe4f087c"
+  integrity sha512-MdhkYYxSW5I6Jpk34gTkAZsuj9sxe0xdyeUQpNa8CgJxG43F+ehZ6scW/IPjoSG9gCXBUJMekq26UrmbVfsLCQ==
   dependencies:
     "@babel/generator" "^7.23.0"
     "@babel/parser" "^7.23.0"
     "@babel/traverse" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/types" "7.6.11"
+    "@storybook/types" "7.6.12"
     fs-extra "^11.1.0"
     recast "^0.23.1"
     ts-dedent "^2.0.0"
@@ -4174,14 +4174,14 @@
   resolved "https://registry.yarnpkg.com/@storybook/docs-mdx/-/docs-mdx-0.1.0.tgz#33ba0e39d1461caf048b57db354b2cc410705316"
   integrity sha512-JDaBR9lwVY4eSH5W8EGHrhODjygPd6QImRbwjAuJNEnY0Vw4ie3bPkeGfnacB3OBW6u/agqPv2aRlR46JcAQLg==
 
-"@storybook/docs-tools@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.6.11.tgz#401d1dcdc67dff7c553b36b6d2355a06edc23107"
-  integrity sha512-totR3O0hF+TIiL6AXH/X+wBu+B0PO5qFSOWFjTioEuI8iA1k6hDvCvt4NfgPGMW2o3ynukjmryyB+khd0QjlaA==
+"@storybook/docs-tools@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.6.12.tgz#d747bc88f5e5a7213b2d9e185fe9b4b85771ca74"
+  integrity sha512-nY2lqEDTd/fR/D91ZLlIp+boSuJtkb8DqHW7pECy61rJqzGq4QpepRaWjQDKnGTgPItrsPfTPOu6iXvXNK07Ow==
   dependencies:
-    "@storybook/core-common" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/doctrine" "^0.0.3"
     assert "^2.1.0"
     doctrine "^3.0.0"
@@ -4192,19 +4192,19 @@
   resolved "https://registry.yarnpkg.com/@storybook/global/-/global-5.0.0.tgz#b793d34b94f572c1d7d9e0f44fac4e0dbc9572ed"
   integrity sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==
 
-"@storybook/manager-api@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.6.11.tgz#63353732f4e92019c8284b4a99fd147591c5c9da"
-  integrity sha512-lr+0HXP+O9zN5mGixrlWfIM6fuPAwHEc4vIgA3MG14zIhlznfZStbLp0n5rRHxvyXnkJbcPtNDCi2CKgWN7++w==
+"@storybook/manager-api@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.6.12.tgz#226f343873b75bfd31db90a54c5829bfd7c6d819"
+  integrity sha512-XA5KQpY44d6mlqt0AlesZ7fsPpm1PCpoV+nRGFBR0YtF6RdPFvrPyHhlGgLkJC4xSyb2YJmLKn8cERSluAcEgQ==
   dependencies:
-    "@storybook/channels" "7.6.11"
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-events" "7.6.11"
+    "@storybook/channels" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/router" "7.6.11"
-    "@storybook/theming" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/router" "7.6.12"
+    "@storybook/theming" "7.6.12"
+    "@storybook/types" "7.6.12"
     dequal "^2.0.2"
     lodash "^4.17.21"
     memoizerific "^1.11.3"
@@ -4212,10 +4212,10 @@
     telejson "^7.2.0"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.11.tgz#fb503e1eda5910e1949ebc9d898a680c75bbc99e"
-  integrity sha512-OtJuRwnkwnXbiKrzZ31tWUo6sOps/idRFoWnxITnoeS/NCq4bHuRtPor2bbHmFDL1mFX+zQuwqVME6eMkQxavQ==
+"@storybook/manager@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.12.tgz#147219c57f4b68d343a9e0ee1563e5214cd09549"
+  integrity sha512-WMWvswJHGiqJFJb98WQMQfZQhLuVtmci4y/VJGQ/Jnq1nJQs76BCtaeGiHcsYmRaAP1HMI4DbzuTSEgca146xw==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
@@ -4223,9 +4223,9 @@
   integrity sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==
 
 "@storybook/nextjs@~7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/nextjs/-/nextjs-7.6.11.tgz#eb36da1697cd7bed812f4f8a90ad0c80c72128ca"
-  integrity sha512-CIf2xlZTwbQTBlkaLx4finGAN9jwwbpp4xx8M2A74RAC4mO5Cy5Un7/vypYx5BMIs+HpxUpRgP4EfYy/Inch7Q==
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/nextjs/-/nextjs-7.6.12.tgz#4a182dbaf2706c702982b8bcbe82dda635176f69"
+  integrity sha512-LotbWSzm0Q3ra0daoX2G40wWC5moU2o+Rg139OL1fWWUBC4tiQM7V3VUzoKP6t9BPii166am7WLmY7r8rN0G+A==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-syntax-bigint" "^7.8.3"
@@ -4240,14 +4240,14 @@
     "@babel/preset-react" "^7.22.15"
     "@babel/preset-typescript" "^7.23.2"
     "@babel/runtime" "^7.23.2"
-    "@storybook/addon-actions" "7.6.11"
-    "@storybook/builder-webpack5" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/core-events" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/preset-react-webpack" "7.6.11"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/react" "7.6.11"
+    "@storybook/addon-actions" "7.6.12"
+    "@storybook/builder-webpack5" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/core-events" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/preset-react-webpack" "7.6.12"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/react" "7.6.12"
     "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
     css-loader "^6.7.3"
@@ -4269,28 +4269,28 @@
     tsconfig-paths "^4.0.0"
     tsconfig-paths-webpack-plugin "^4.0.1"
 
-"@storybook/node-logger@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.11.tgz#baa08fc189ba0699e9919280c50f52b2d4642f89"
-  integrity sha512-3vFUWcRVfYkMzTO/FiNap2CIvMonz1gVISYIxRHQv32hF+VNmeMb1t7AzWb1zxZIOZp+bdMmCPR4UfVg5EJw8w==
+"@storybook/node-logger@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.12.tgz#2232fc45ca8439649d8cb2cefe38f0a97c1aa275"
+  integrity sha512-iS44/EjfF6hLecKzICmcpQoB9bmVi4tXx5gVXnbI5ZyziBibRQcg/U191Njl7wY2ScN/RCQOr8lh5k57rI3Prg==
 
-"@storybook/postinstall@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.6.11.tgz#2319574c5f8d3e47a8ae824b72683ac76d479e57"
-  integrity sha512-NNhOVeUvgcHqSUm2DtHrbfZtLuliW/iXh32AY+04lsNIlwVLAhjfWtubqoVcHUOD+4CV/6oBnyudEgslv9Bo0w==
+"@storybook/postinstall@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.6.12.tgz#a230b0641ca793582580017cd1ed495ecaf74394"
+  integrity sha512-uR0mDPxLzPaouCNrLp8vID8lATVTOtG7HB6lfjjzMdE3sN6MLmK9n2z2nXjb5DRRxOFWMeE1/4Age1/Ml2tnmA==
 
-"@storybook/preset-react-webpack@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.6.11.tgz#594fa708d8191eb1ffddf6c5e0958efe18f6d46d"
-  integrity sha512-2KEsBdPpvxhby/2lV3mT0jfYi2KTLfpL1brQFYOY+1w2wPfMMAaUvEFBKj1UlG85RzqiNoQEjMSGqdVcw7MYUw==
+"@storybook/preset-react-webpack@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.6.12.tgz#32e910448d35882f3e9ef7c50997075e77576a85"
+  integrity sha512-j6gyC2KVyjO0zIvGtGqL4NoQKbTgMAoUYjF6w1UigoiU53rjxkrq2NMt+BnMxXnYwD+iXMoxyUIex01NBUpNnA==
   dependencies:
     "@babel/preset-flow" "^7.22.15"
     "@babel/preset-react" "^7.22.15"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.11"
-    "@storybook/core-webpack" "7.6.11"
-    "@storybook/docs-tools" "7.6.11"
-    "@storybook/node-logger" "7.6.11"
-    "@storybook/react" "7.6.11"
+    "@storybook/core-webpack" "7.6.12"
+    "@storybook/docs-tools" "7.6.12"
+    "@storybook/node-logger" "7.6.12"
+    "@storybook/react" "7.6.12"
     "@storybook/react-docgen-typescript-plugin" "1.0.6--canary.9.0c3f3b7.0"
     "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
@@ -4302,17 +4302,17 @@
     semver "^7.3.7"
     webpack "5"
 
-"@storybook/preview-api@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.11.tgz#eda62c774dbd87a9c76eb328e29f6cac89b45146"
-  integrity sha512-y9+gAbeS26/hEBkaF9abxfkzKJhgLtVaz1f5rhUMYdmBotq433J97dzfTSDtJA9cvA9Jw4QEKksY8TiSenZ3Pw==
+"@storybook/preview-api@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.12.tgz#d431cc76d733c17ba1943a31fc3297de8f40c467"
+  integrity sha512-uSzeMSLnCRROjiofJP0F0niLWL+sboQ5ktHW6BAYoPwprumXduPxKBUVEZNxMbVYoAz9v/kEZmaLauh8LRP2Hg==
   dependencies:
-    "@storybook/channels" "7.6.11"
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-events" "7.6.11"
+    "@storybook/channels" "7.6.12"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-events" "7.6.12"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/types" "7.6.11"
+    "@storybook/types" "7.6.12"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -4322,10 +4322,10 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/preview@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.6.11.tgz#c4228b8440b2c299bca4a1a1dd93377f9355d80c"
-  integrity sha512-DrCH24K3ivm7YGSP6OQknJg7i7vdzZnxhByQ3aC1OWcYVhdjtATrKfnHGkY/aDpNi1hUeGCQb0TKDpbMLzI8qQ==
+"@storybook/preview@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.6.12.tgz#a1cefa430b5bc0768e0f623efd779bdaa9b0f223"
+  integrity sha512-7vbeqQY3X+FCt/ccgCuBmj4rkbQebLHGEBAt8elcX0E2pr7SGW57lWhnasU3jeMaz7tNrkcs0gfl4hyVRWUHDg==
 
 "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0":
   version "1.0.6--canary.9.0c3f3b7.0"
@@ -4340,33 +4340,33 @@
     react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
-"@storybook/react-dom-shim@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.6.11.tgz#7f98cbc62c696be65f92859b0f046b660ba45bda"
-  integrity sha512-jRW8IIgFSKHDTvlX6y8slYZPJftu1++HzoceBT0Taru5aEd86dBAHGMYVsDRDYK9ruNbagsTgJbplO/+M7WAQg==
+"@storybook/react-dom-shim@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.6.12.tgz#190dddfda677a46453e253a95dacf5a7175bb191"
+  integrity sha512-P8eu/s/RQlc/7Yvr260lqNa6rttxIYiPUuHQBu9oCacwkpB3Xep2R/PUY2CifRHqlDhaOINO/Z79oGZl4EBQRQ==
 
 "@storybook/react-webpack5@~7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.6.11.tgz#f7453d47ae30ca430fa193a63e8af0e036f28ffe"
-  integrity sha512-/Oo/dFgsKSlx6Ky8fAWD15FX7RcSqwHqZFfScpoCEM/c1j4ym9LtRhJWkS+8aG/zX5Q6e3r9TjjeJ1P/S9MbaQ==
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.6.12.tgz#7fcf5577015847245d048bb43aa1fd5659a85f59"
+  integrity sha512-MyIqGF8QrL6v5iCLDG3zQ1Yh8faUJcwt155BOjKWCjXXpWkCklCucuSHkhN79FkWMO6xMwjAlV2AuYBL8wraeg==
   dependencies:
-    "@storybook/builder-webpack5" "7.6.11"
-    "@storybook/preset-react-webpack" "7.6.11"
-    "@storybook/react" "7.6.11"
+    "@storybook/builder-webpack5" "7.6.12"
+    "@storybook/preset-react-webpack" "7.6.12"
+    "@storybook/react" "7.6.12"
     "@types/node" "^18.0.0"
 
-"@storybook/react@7.6.11", "@storybook/react@~7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.6.11.tgz#222ea934099109e00340e30ec2b68660e1ce0c14"
-  integrity sha512-q2YPizNtL5DKeGATE6cKUbT/uvRbOJOUfb+VW/Z7O9MkrAgYFC0ybiZHOgT48Ifog99VoKv9l7fkfCVIY5klfw==
+"@storybook/react@7.6.12", "@storybook/react@~7.6.11":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.6.12.tgz#371c9c1b204a7f30087051e835b6d0256d6e18d8"
+  integrity sha512-ITDRGi79Qg+z1kGYv+yyJESz/5AsJVdBTMO7tr1qV7gmHElkASt6UR8SBSqKgePOnYgy3k/1PLfbzOs6G4OgYQ==
   dependencies:
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-client" "7.6.11"
-    "@storybook/docs-tools" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-client" "7.6.12"
+    "@storybook/docs-tools" "7.6.12"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.6.11"
-    "@storybook/react-dom-shim" "7.6.11"
-    "@storybook/types" "7.6.11"
+    "@storybook/preview-api" "7.6.12"
+    "@storybook/react-dom-shim" "7.6.12"
+    "@storybook/types" "7.6.12"
     "@types/escodegen" "^0.0.6"
     "@types/estree" "^0.0.51"
     "@types/node" "^18.0.0"
@@ -4382,12 +4382,12 @@
     type-fest "~2.19"
     util-deprecate "^1.0.2"
 
-"@storybook/router@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.6.11.tgz#411077e72d87dc8a2146ede67c2ad2192a947f7c"
-  integrity sha512-d6Jcy3ca/Vod4C7RmaVpxY3/gRLF3MxbV4KnLEvMeRtdHnGYCOLLIC/nwBTf2A5iCjbmxDheeWNE9G01wnN8Kw==
+"@storybook/router@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.6.12.tgz#c8699e2c0a5d1ac644e96f72150ab993a7ea132a"
+  integrity sha512-1fqscJbePFJXhapqiv7fAIIqAvouSsdPnqWjJGJrUMR6JBtRYMcrb3MnDeqi9OYnU73r65BrQBPtSzWM8nP0LQ==
   dependencies:
-    "@storybook/client-logger" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
@@ -4402,36 +4402,36 @@
     shelljs "^0.8.1"
     yargs "^15.0.0"
 
-"@storybook/telemetry@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.11.tgz#16f80b174022c2185f16c19bbe2eb4ffdea8c3db"
-  integrity sha512-i5HaKVXgpdVf38c42EVUeUM2HC7RuL/HDck1YX+Ir1IT6Id4e/3Ji1tAqGIHP5rwR2kUeT5s9vey9Il0GGIOkQ==
+"@storybook/telemetry@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.12.tgz#8a49317466c98a184cd01ad6c53162ee1c05a626"
+  integrity sha512-eBG3sLb9CZ05pyK2JXBvnaAsxDzbZH57VyhtphhuZmx0DqF/78qIoHs9ebRJpJWV0sL5rtT9vIq8QXpQhDHLWg==
   dependencies:
-    "@storybook/client-logger" "7.6.11"
-    "@storybook/core-common" "7.6.11"
-    "@storybook/csf-tools" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
+    "@storybook/core-common" "7.6.12"
+    "@storybook/csf-tools" "7.6.12"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
     fs-extra "^11.1.0"
     read-pkg-up "^7.0.1"
 
-"@storybook/theming@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.6.11.tgz#019e5a64a110caa4ecb647793e05e3783e1c93e7"
-  integrity sha512-emfkWAkR0zul/374GmbEniUDHJ27VcrioZAm+TKhiYHAwwklA+SizERLtApXs2yc2zYbHFW/r/myaNWRt6LSww==
+"@storybook/theming@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.6.12.tgz#d05057ace62718e07b20ca0665c93f73d117081c"
+  integrity sha512-P4zoMKlSYbNrWJjQROuz+DZSDEpdf3TUvk203EqBRdElqw2EMHcqZ8+0HGPFfVHpqEj05+B9Mr6R/Z/BURj0lw==
   dependencies:
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@storybook/client-logger" "7.6.11"
+    "@storybook/client-logger" "7.6.12"
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
 
-"@storybook/types@7.6.11":
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.11.tgz#38b01ca86f28346cb6a9df011986a3889b294309"
-  integrity sha512-IjkOx8swVpFAR/t1IgjAEozaMGLcQAP1e7SnTuwNsa1wcXKQOd3+hhyPjS1ZukULXN7IXW8UIDvhP3hXoRYxVQ==
+"@storybook/types@7.6.12":
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.12.tgz#af7813e6f4ca31c500f9e28af5f591c8b1ea1b13"
+  integrity sha512-Wsbd+NS10/2yMHQ/26rXHflXam0hm2qufTFiHOX6VXZWxij3slRU88Fnwzp+1QSyjXb0qkEr8dOx7aG00+ItVw==
   dependencies:
-    "@storybook/channels" "7.6.11"
+    "@storybook/channels" "7.6.12"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
@@ -4946,9 +4946,9 @@
   integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
 
 "@types/mdx@^2.0.0":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.10.tgz#0d7b57fb1d83e27656156e4ee0dfba96532930e4"
-  integrity sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.11.tgz#21f4c166ed0e0a3a733869ba04cd8daea9834b8e"
+  integrity sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw==
 
 "@types/mime-types@^2.1.0":
   version "2.1.4"
@@ -4991,9 +4991,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "20.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.10.tgz#6c3de8974d65c362f82ee29db6b5adf4205462f9"
-  integrity sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==
+  version "20.11.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.15.tgz#b853a86cfedbc768360c552b4653302b4e7417bf"
+  integrity sha512-gscmuADZfvNULx1eyirVbr3kVOVZtpQtzKMCZpeSZcN6MfbkRXAR4s9/gsQ4CzxLHw6EStDtKLNtSDL3vbq05A==
   dependencies:
     undici-types "~5.26.4"
 
@@ -5010,9 +5010,9 @@
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/node@^18.0.0":
-  version "18.19.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.10.tgz#4de314ab66faf6bc8ba691021a091ddcdf13a158"
-  integrity sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==
+  version "18.19.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.13.tgz#c3e989ca967b862a1f6c8c4148fe31865eedaf1a"
+  integrity sha512-kgnbRDj8ioDyGxoiaXsiu1Ybm/K14ajCgMOkwiqpHrnF7d7QiYRoRqHIpglMMs3DwXinlK4qJ8TZGlj4hfleJg==
   dependencies:
     undici-types "~5.26.4"
 
@@ -5078,9 +5078,9 @@
     csstype "^3.0.2"
 
 "@types/react@>=16":
-  version "18.2.48"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.48.tgz#11df5664642d0bd879c1f58bc1d37205b064e8f1"
-  integrity sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==
+  version "18.2.51"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.51.tgz#01ede6dfc712796257a3443bf8d613149e5c322a"
+  integrity sha512-XeoMaU4CzyjdRr3c4IQQtiH7Rpo18V07rYZUucEZQwOUEtGgTXv7e6igQiQ+xnV6MbMe1qjEmKdgMNnfppnXfg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6122,9 +6122,9 @@ asynckit@^0.4.0:
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz#ac812d8ce5a6b976d738e1c45f08d0b00bc7d725"
+  integrity sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -6714,9 +6714,9 @@ caniuse-lite@^1.0.30001406:
   integrity sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==
 
 caniuse-lite@^1.0.30001580:
-  version "1.0.30001581"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz#0dfd4db9e94edbdca67d57348ebc070dece279f4"
-  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
+  version "1.0.30001582"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001582.tgz#db3070547ce0b48d9f44a509b86c4a02ba5d9055"
+  integrity sha512-vsJG3V5vgfduaQGVxL53uSX/HUzxyr2eA8xCo36OLal7sRcSZbibJtLeh0qja4sFOr/QQGt4opB4tOy+eOgAxg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -7485,21 +7485,7 @@ css-color-keywords@^1.0.0:
   resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
 
-css-loader@^6.7.1, css-loader@^6.7.3:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.9.1.tgz#9ec9a434368f2bdfeffbf8f6901a1ce773586c6b"
-  integrity sha512-OzABOh0+26JKFdMzlK6PY1u5Zx8+Ck7CVRlcGNZoY9qwJjdfu2VWFuprTIpPW+Av5TZTVViYWcFQaEEQURLknQ==
-  dependencies:
-    icss-utils "^5.1.0"
-    postcss "^8.4.33"
-    postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.4"
-    postcss-modules-scope "^3.1.1"
-    postcss-modules-values "^4.0.0"
-    postcss-value-parser "^4.2.0"
-    semver "^7.5.4"
-
-css-loader@~6.10.0:
+css-loader@^6.7.1, css-loader@^6.7.3, css-loader@~6.10.0:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.10.0.tgz#7c172b270ec7b833951b52c348861206b184a4b7"
   integrity sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==
@@ -8485,9 +8471,9 @@ ejs@^3.1.8:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.648:
-  version "1.4.650"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.650.tgz#b38ef9de16991b9f7b924246770576ab91ab3d64"
-  integrity sha512-sYSQhJCJa4aGA1wYol5cMQgekDBlbVfTRavlGZVr3WZpDdOPcp6a6xUnFfrt8TqZhsBYYbDxJZCjGfHuGupCRQ==
+  version "1.4.653"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.653.tgz#832ab25e80ad698ac09c1ca547bd9ee6cce7df10"
+  integrity sha512-wA2A2LQCqnEwQAvwADQq3KpMpNwgAUBnRmrFgRzHnPhbQUFArTR32Ab46f4p0MovDLcg4uqd4nCsN2hTltslpA==
 
 elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -10910,9 +10896,9 @@ ignore@^5.0.4, ignore@^5.1.1:
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 ignore@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
-  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
+  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
 image-size@^1.0.0:
   version "1.1.1"
@@ -12481,9 +12467,9 @@ magic-string@^0.27.0:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
 magic-string@^0.30.5:
-  version "0.30.5"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
-  integrity sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==
+  version "0.30.6"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.6.tgz#996e21b42f944e45591a68f0905d6a740a12506c"
+  integrity sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
@@ -14559,7 +14545,14 @@ pnp-webpack-plugin@^1.7.0:
   dependencies:
     ts-pnp "^1.1.6"
 
-polished@^4.2.2, polished@~4.2.2:
+polished@^4.2.2:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.3.0.tgz#f25cfb64940b26262ed0586cb97feca155d97926"
+  integrity sha512-ggU2H9FdSRwmcfGEPFaUNoX+P6cVbmIhobEpVBCiclCm6Ku+vlzh7wmhBRplYUqsECt8ZHwM8CaVjLBzLMJB1g==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+
+polished@~4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz"
   integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
@@ -16431,11 +16424,11 @@ storybook-react-i18next@~2.0.1:
     storybook-i18n "2.0.13"
 
 storybook@~7.6.11:
-  version "7.6.11"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.11.tgz#a727651bcc27a9ca7cd907ac084b2fe12775bf6e"
-  integrity sha512-5giiG9qImwjatA+jhgVuAMERMjWYV5biHG5ZLU+3KPwgaAaERstojKGPfR+bZRf5ZqtNDw4qCIH3RSc49NCUoQ==
+  version "7.6.12"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.12.tgz#63a45b2a32f204abb77c8c20ba85ecba21990500"
+  integrity sha512-zcH9CwIsE8N4PX3he5vaJ3mTTWGxu7cxJ/ag9oja/k3N5/IvQjRyIU1TLkRVb28BB8gaLyorpnc4C4aLVGy4WQ==
   dependencies:
-    "@storybook/cli" "7.6.11"
+    "@storybook/cli" "7.6.12"
 
 stream-browserify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bump all storybook packages with `yarn upgrade-interactive`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project
- lib-classifier
- lib-react-components

## How to Review
[Release notes for Storybook 7.6.12](https://github.com/storybookjs/storybook/releases/tag/v7.6.12). It's a bugfix for the `upgrade` command, so shouldn't make any changes to the published storybooks.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
