### PR TITLE
refactor: sync annotate visibility when workflow changes

### DIFF
--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -47,7 +47,11 @@ const SubjectViewer = types
       }
       return false
     },
-    
+ 
+    get hasAnnotateTask () {
+      return getRoot(self)?.workflowSteps.hasAnnotateTask
+    },
+
     get interactionMode () {
       // Default interaction mode is 'annotate'
       return (!self.annotate && self.move) ? 'move' : 'annotate'
@@ -67,20 +71,12 @@ const SubjectViewer = types
     }
 
     return {
-      afterRootInitialize () {
-        // afterRootInitialize() enables listening on store.workflowSteps because they are both now initialized
-        reaction(
-          () => getRoot(self)?.workflowSteps.hasAnnotateTask,
-          (val) => {
-            self.setAnnotateVisibility(val)
-          }
-        )
-        
-        // reactions handle any changes to state, not the initial state
-        self.setAnnotateVisibility(getRoot(self)?.workflowSteps.hasAnnotateTask)
-      },
-      
       afterAttach () {
+        function _syncAnnotateVisibility() {
+          console.log('syncing annotate visibility', self.hasAnnotateTask)
+          self.setAnnotateVisibility(self.hasAnnotateTask)
+        }
+        addDisposer(self, autorun(_syncAnnotateVisibility))
         createSubjectObserver()
       },
 


### PR DESCRIPTION
Add `workflowSteps.hasAnnotateTask` to the `SubjectViewerStore` model as
a view. Add an `autorun` reaction which syncs `subjectViewer.annotateVisibility`
when `subjectViewer.hasAnnotateTask` changes.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
